### PR TITLE
Removes escaping in `<style>` tags

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -12,6 +12,10 @@ function isInsideScript(node) {
   return node.parentNode && node.parentNode.localName === 'script';
 }
 
+function isInsideStyle(node) {
+  return node.parentNode && node.parentNode.localName === 'style';
+}
+
 function * serializeElement(el) {
   if(oceanSerializeSymbol in el) {
     yield * el[oceanSerializeSymbol]();
@@ -52,7 +56,7 @@ export function * serialize(node) {
       break;
     }
     case 3: {
-      if(isInsideScript(node))
+      if(isInsideScript(node) || isInsideStyle(node))
         yield node.data;
       else 
         yield escapeHTML(node.data);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -264,6 +264,24 @@ Deno.test('Text is not serialized inside of scripts', async () => {
   assertEquals(out, '<my-text-in-script-el><script>html`<div>inner</div>`;</script></my-text-in-script-el>');
 });
 
+Deno.test('Text is not serialized inside of style tags', async () => {
+  let { html } = new Ocean({ document });
+  customElements.define('my-text-in-style-el', class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open'});
+    }
+    connectedCallback() {
+      this.shadowRoot.innerHTML = `
+        <style>#test > div { color: red; }</style>
+      `;
+    }
+  });
+  let iter = html`<my-text-in-style-el></my-text-in-style-el>`;
+  let out = await consume(iter);
+  assertStringIncludes(out, '<style>#test > div { color: red; }</style>', 'no escaping in style tags');
+});
+
 Deno.test('Attribute values are escaped in HTML', async () => {
   let { html } = new Ocean({ document });
   let iter = html`<div a='"a'></div>`;


### PR DESCRIPTION
Fixes #39

Removes HTML escaping when inside `<style>` tags so that child combinators (`>`) are not escaped. This also allows other characters through (`<`, `&`) but I think that's safe as they are not interpreted within `<style>` tags.